### PR TITLE
Some basic keyboard usability improvements

### DIFF
--- a/src/GifWin/MainWindow.xaml
+++ b/src/GifWin/MainWindow.xaml
@@ -55,7 +55,7 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <local:SearchTextBox x:Name="search" Hint="filter" Margin="10" Style="{DynamicResource LargeEntry}" Text="{Binding FilterText,Mode=OneWayToSource,Delay=300,UpdateSourceTrigger=PropertyChanged}" />
+        <local:SearchTextBox x:Name="search" KeyUp="SearchBoxKeyPressed" Hint="filter" Margin="10" Style="{DynamicResource LargeEntry}" Text="{Binding FilterText,Mode=OneWayToSource,Delay=300,UpdateSourceTrigger=PropertyChanged}" />
 
         <ListBox x:Name="imageList" Grid.Row="1" Margin="10" ItemsSource="{Binding Images}" BorderThickness="0" SelectionMode="Single" KeyDown="GifEntryKeyPressed" MouseUp="GifEntryClicked" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
             <ListBox.ItemsPanel>

--- a/src/GifWin/MainWindow.xaml.cs
+++ b/src/GifWin/MainWindow.xaml.cs
@@ -72,7 +72,8 @@ namespace GifWin
 
         private void GifEntryKeyPressed (object sender, KeyEventArgs e)
         {
-            CopyImage();
+            if (e.Key == Key.Return || e.Key == Key.Enter)
+                CopyImage();
         }
 
         private void OnWindowKeyUp (object sender, KeyEventArgs e)

--- a/src/GifWin/MainWindow.xaml.cs
+++ b/src/GifWin/MainWindow.xaml.cs
@@ -80,5 +80,15 @@ namespace GifWin
             if (e.Key == Key.Escape)
                 Hide();
         }
+
+        private void SearchBoxKeyPressed(object sender, KeyEventArgs e)
+        {
+            if (SearchStates.CurrentState == null || SearchStates.CurrentState.Name != "Searching")
+                return;
+
+            if (e.Key == Key.Down) {
+                imageList.Focus();
+            }
+        }
     }
 }


### PR DESCRIPTION
Make images navigable using the keyboard while searching -- pressing the Down key in the search box will shift focus to the image list and let you navigate and choose an image with Return.