### PR TITLE
Only select on click if on image

### DIFF
--- a/src/GifWin/MainWindow.xaml.cs
+++ b/src/GifWin/MainWindow.xaml.cs
@@ -73,9 +73,9 @@ namespace GifWin
             });
         }
 
-        void CopyImage ()
+        void CopyImage (GifEntryViewModel entry = null)
         {
-            var entry = (GifEntryViewModel)imageList.SelectedItem;
+            entry = entry ?? (GifEntryViewModel)imageList.SelectedItem;
             if (entry == null)
                 return;
 
@@ -146,7 +146,12 @@ namespace GifWin
             if (e.ChangedButton != MouseButton.Left)
                 return;
 
-            CopyImage ();
+            var element = InputHitTest (e.GetPosition (this)) as FrameworkElement;
+            var entry = element?.DataContext as GifEntryViewModel;
+            if (entry == null)
+                return;
+
+            CopyImage (entry);
         }
 
         void GifEntryKeyPressed (object sender, KeyEventArgs e)


### PR DESCRIPTION
We shouldn't use the selected image just from clicking anywhere on the
window. Fixes #30